### PR TITLE
Fix form invalidation on text overflow

### DIFF
--- a/src/credit-card.validator.ts
+++ b/src/credit-card.validator.ts
@@ -19,7 +19,11 @@ export class CreditCardValidator {
       return {'ccNumber': true};
     }
 
-    if (card.length.includes(num.length) && (card.luhn === false || CreditCard.luhnCheck(num))) {
+    const upperlength = card.length[card.length.length - 1];
+    if (
+      card.length.includes(num.length) && (card.luhn === false || CreditCard.luhnCheck(num)) ||
+      num.length > upperlength
+    ) {
       return null;
     }
 


### PR DESCRIPTION
###### Description
(Pulled from [ISSUE 10](https://github.com/nogorilla/angular-cc-library/issues/10))
If you enter a credit card that is too long ( say the test card 4111 1111 1111 1111), if you just keep spamming the 1s when it hits max length it will remove any excess characters at the end, but the field is still marked invalid, and to work around you have to remove the last digit and re-enter it.


+ This PR Addresses [Issue 10 "Maxlength clamping causes field to be marked invalid "](https://github.com/nogorilla/angular-cc-library/issues/10)  described above