### PR TITLE
Ensure Proper CC Number Validation When Input Overflows

### DIFF
--- a/src/credit-card.validator.ts
+++ b/src/credit-card.validator.ts
@@ -20,11 +20,15 @@ export class CreditCardValidator {
     }
 
     const upperlength = card.length[card.length.length - 1];
-    if (
-      card.length.includes(num.length) && (card.luhn === false || CreditCard.luhnCheck(num)) ||
-      num.length > upperlength
-    ) {
+    if (card.length.includes(num.length) && (card.luhn === false || CreditCard.luhnCheck(num))) {
       return null;
+    }
+
+    if (num.length > upperlength) {
+      const registeredNum = num.substring(0, upperlength);
+      if (CreditCard.luhnCheck(registeredNum)) {
+        return null;
+      }
     }
 
     return {'ccNumber': true};


### PR DESCRIPTION
###### DESCRIPTION

This is a follow up on the [PR from yesterday](https://github.com/nogorilla/angular-cc-library/pull/18); as I discovered there was a bug with the fix. 

###### BUG SUMMARY
Validation works correctly, up until the point where the user enters more numbers after the allowed max length.
+ If the input number is *valid*, typing extra numbers shouldn't invalidate the input value (Works as expected ✅ )
+ If the input number is *invalid*, typing extra numbers makes the input number valid (Not the expected behavior ❌  )


This update ensures that the input value is also correctly validated when a user enters more numbers after the max length.
The extra characters is ignored while the characters within the allowed length for the card type is re-validated.
