### PR TITLE
Credit Card Format Directive Updates

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,14 +13,15 @@ module.exports = function (config) {
       },
 
       webpack: {
+        devtool: 'inline-source-map',
         resolve: {
-          extensions: ['', '.ts', '.js']
+          extensions: [ '.js', '.ts' ]
         },
         module: {
           loaders: [
             {
                 test: /\.ts$/,
-                loader: 'ts'
+                loader: 'ts-loader'
             },
             {
                 test: /\.html$/,

--- a/src/directives/credit-card-format.directive.spec.ts
+++ b/src/directives/credit-card-format.directive.spec.ts
@@ -1,0 +1,137 @@
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import {CreditCardFormatDirective} from './credit-card-format.directive';
+import { Component, DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+
+@Component({
+  template: `<input type="tel" ccNumber>`
+})
+class TestCreditCardFormatComponent {
+}
+
+describe('Directive: CreditCardFormat', () => {
+  let component: TestCreditCardFormatComponent;
+  let fixture: ComponentFixture<TestCreditCardFormatComponent>;
+  let inputEl: DebugElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestCreditCardFormatComponent, CreditCardFormatDirective]
+    });
+    fixture = TestBed.createComponent(TestCreditCardFormatComponent);
+    component = fixture.componentInstance;
+    inputEl = fixture.debugElement.query(By.css('input'));
+  });
+
+  it('formats card number tick by tick', fakeAsync(() => {
+
+    inputEl.nativeElement.value = '4111 1111';
+    inputEl.triggerEventHandler('keydown', {keyCode: 49, which: 49});
+    fixture.detectChanges();
+    tick(10);
+    expect(inputEl.nativeElement.value).toBe('4111 1111');
+
+    inputEl.triggerEventHandler('keypress', {keyCode: 49, which: 49});
+    fixture.detectChanges();
+    tick(10);
+    expect(inputEl.nativeElement.value).toBe('4111 1111');
+
+    // the value is changed here by the browser as default behavior
+    inputEl.nativeElement.value = '4111 11111';
+
+    inputEl.triggerEventHandler('input', null);
+    fixture.detectChanges();
+    tick(10);
+    expect(inputEl.nativeElement.value).toBe('4111 1111 1');
+
+    inputEl.triggerEventHandler('keyup', {keyCode: 49, which: 49});
+    fixture.detectChanges();
+    tick(10);
+    expect(inputEl.nativeElement.value).toBe('4111 1111 1');
+
+  }));
+
+  it('formats card number one tick', fakeAsync(() => {
+
+    inputEl.nativeElement.value = '4111 1111';
+    inputEl.triggerEventHandler('keydown', {keyCode: 49, which: 49});
+    fixture.detectChanges();
+    expect(inputEl.nativeElement.value).toBe('4111 1111');
+
+    inputEl.triggerEventHandler('keypress', {keyCode: 49, which: 49});
+    fixture.detectChanges();
+    expect(inputEl.nativeElement.value).toBe('4111 1111');
+
+    // the value is changed here by the browser as default behavior
+    inputEl.nativeElement.value = '4111 11111';
+
+    inputEl.triggerEventHandler('input', null);
+    fixture.detectChanges();
+    expect(inputEl.nativeElement.value).toBe('4111 11111');
+
+    inputEl.triggerEventHandler('keyup', {keyCode: 49, which: 49});
+    fixture.detectChanges();
+    expect(inputEl.nativeElement.value).toBe('4111 11111');
+
+    tick(10);
+    expect(inputEl.nativeElement.value).toBe('4111 1111 1');
+
+  }));
+
+  it('deletes from middle of value', fakeAsync(() => {
+
+    inputEl.nativeElement.value = '4111 1111 111';
+    inputEl.nativeElement.selectionStart = 5;
+    inputEl.nativeElement.selectionEnd = 5;
+    inputEl.nativeElement.focus();
+
+    let defPrevented = false;
+
+    inputEl.triggerEventHandler('keydown', {keyCode: 8, which: 8, preventDefault: function() { defPrevented = true; }});
+    fixture.detectChanges();
+    tick(10);
+    expect(inputEl.nativeElement.value).toBe('4111 1111 11');
+    expect(inputEl.nativeElement.selectionStart).toBe(3);
+    expect(inputEl.nativeElement.selectionEnd).toBe(3);
+    expect(defPrevented).toBeTruthy();
+
+  }));
+
+  it('deletes from beginning of value', fakeAsync(() => {
+
+    inputEl.nativeElement.value = '5 411 1111';
+    inputEl.nativeElement.selectionStart = 2;
+    inputEl.nativeElement.selectionEnd = 2;
+    inputEl.nativeElement.focus();
+
+    let defPrevented = false;
+
+    inputEl.triggerEventHandler('keydown', {keyCode: 8, which: 8, preventDefault: function() { defPrevented = true; }});
+    fixture.detectChanges();
+    tick(10);
+    expect(inputEl.nativeElement.value).toBe('4111 111');
+    expect(inputEl.nativeElement.selectionStart).toBe(0);
+    expect(inputEl.nativeElement.selectionEnd).toBe(0);
+    expect(defPrevented).toBeTruthy();
+
+  }));
+
+  it('does not modify deleting from end of value', fakeAsync(() => {
+
+    inputEl.nativeElement.value = '4111 1111 111';
+    inputEl.nativeElement.selectionStart = 13;
+    inputEl.nativeElement.selectionEnd = 13;
+    inputEl.nativeElement.focus();
+
+    let defPrevented = false;
+
+    inputEl.triggerEventHandler('keydown', {keyCode: 8, which: 8, preventDefault: function() { defPrevented = true; }});
+    fixture.detectChanges();
+    tick(10);
+    expect(inputEl.nativeElement.value).toBe('4111 1111 111');
+    expect(inputEl.nativeElement.selectionStart).toBe(13);
+    expect(inputEl.nativeElement.selectionEnd).toBe(13);
+    expect(defPrevented).toBeFalsy();
+
+  }));
+});

--- a/src/directives/credit-card-format.directive.ts
+++ b/src/directives/credit-card-format.directive.ts
@@ -119,7 +119,6 @@ export class CreditCardFormatDirective {
 
   private reFormatCardNumber(e) {
     setTimeout(() => {
-      console.log('reFormatCardNumber TO');
       let value = CreditCard.replaceFullWidthChars(this.target.value);
       value = CreditCard.formatCardNumber(value);
       this.target.selectionStart = this.target.selectionEnd = CreditCard.safeVal(value, this.target);


### PR DESCRIPTION
This fixes some problems I was seeing with the credit card format directive on iOS. Example value is '4111 1111 111'. I would enter another one and the result would be '4111 1111 1111 1'. Also fix deleting in the middle of the value so that if the character to delete is a space it will also delete the next character, and the cursor stays in the expected location.

Also some changes to get tests to run. I had some trouble with that. I added unit tests that pass, but the other test file was not passing for me from the beginning.