### PR TITLE
fix: Input refocusing in IE11

### DIFF
--- a/src/directives/credit-card-format.directive.spec.ts
+++ b/src/directives/credit-card-format.directive.spec.ts
@@ -39,6 +39,7 @@ describe('Directive: CreditCardFormat', () => {
     // the value is changed here by the browser as default behavior
     inputEl.nativeElement.value = '4111 11111';
 
+    inputEl.nativeElement.focus();
     inputEl.triggerEventHandler('input', null);
     fixture.detectChanges();
     tick(10);
@@ -69,6 +70,7 @@ describe('Directive: CreditCardFormat', () => {
     fixture.detectChanges();
     expect(inputEl.nativeElement.value).toBe('4111 11111');
 
+    inputEl.nativeElement.focus();
     inputEl.triggerEventHandler('keyup', {keyCode: 49, which: 49});
     fixture.detectChanges();
     expect(inputEl.nativeElement.value).toBe('4111 11111');

--- a/src/directives/credit-card-format.directive.ts
+++ b/src/directives/credit-card-format.directive.ts
@@ -121,7 +121,9 @@ export class CreditCardFormatDirective {
     setTimeout(() => {
       let value = CreditCard.replaceFullWidthChars(this.target.value);
       value = CreditCard.formatCardNumber(value);
-      this.target.selectionStart = this.target.selectionEnd = CreditCard.safeVal(value, this.target);
+      if (this.target === document.activeElement) {
+        this.target.selectionStart = this.target.selectionEnd = CreditCard.safeVal(value, this.target);
+      }
     });
   }
 

--- a/src/directives/cvc-format.directive.ts
+++ b/src/directives/cvc-format.directive.ts
@@ -33,7 +33,9 @@ export class CvcFormatDirective {
     setTimeout(() => {
       let val = CreditCard.replaceFullWidthChars(this.target.value);
       val = val.replace(/\D/g, '').slice(0, 4);
-      this.target.selectionStart = this.target.selectionEnd = CreditCard.safeVal(val, this.target);
+      if (this.target === document.activeElement) {
+        this.target.selectionStart = this.target.selectionEnd = CreditCard.safeVal(val, this.target);
+      }
     });
   }
 

--- a/src/directives/expiry-format.directive.ts
+++ b/src/directives/expiry-format.directive.ts
@@ -105,7 +105,9 @@ export class ExpiryFormatDirective {
       let val = this.target.value;
       val = CreditCard.replaceFullWidthChars(val);
       val = CreditCard.formatExpiry(val);
-      this.target.selectionStart = this.target.selectionEnd = CreditCard.safeVal(val, this.target);
+      if (this.target === document.activeElement) {
+        this.target.selectionStart = this.target.selectionEnd = CreditCard.safeVal(val, this.target);
+      }
     });
   }
 

--- a/src/shared/credit-card.spec.ts
+++ b/src/shared/credit-card.spec.ts
@@ -12,7 +12,7 @@ describe('Shared: Credit Card', () => {
       type: 'visa',
       patterns: [4],
       format: /(\d{1,4})/g,
-      length: [13, 16],
+      length: [13, 16, 19],
       cvvLength: [3],
       luhn: true
     });
@@ -69,8 +69,7 @@ describe('Shared: Credit Card', () => {
       selectionEnd: 2
     };
 
-    expect(CreditCard.safeVal(value, target)).toBe(false);
-
+    expect(CreditCard.safeVal(value, target)).toBe(null);
 
     let element = document.createElement('input');
     document.body.appendChild(element);
@@ -93,7 +92,7 @@ describe('Shared: Credit Card', () => {
 
     expect(CreditCard.isCardNumber(key, target)).toBe(true);
 
-    target.value = '41111111111111111';
+    target.value = '41111111111111111111';
     expect(CreditCard.isCardNumber(key, target)).toBe(false);
 
   });
@@ -151,4 +150,3 @@ describe('Shared: Credit Card', () => {
     expect(CreditCard.luhnCheck('4511111111111111')).toBe(false);
   });
 });
-


### PR DESCRIPTION
When clicking between empty inputs in IE11, the edited lines cause the previously active input to refocus, breaking the UI.

By checking the current target is the active elements, it looks like it fixes it and maintains current behaviour.

Have updated the tests to comply with the new behaviour and fixed a couple of other tests that look like they were out of date too.

Fixes #34 